### PR TITLE
fix: fix_block関数の引数に空白を追加

### DIFF
--- a/chapter06/src/game.rs
+++ b/chapter06/src/game.rs
@@ -100,7 +100,7 @@ pub fn is_collision(field: &Field, pos: &Position, block: BlockKind) -> bool {
 }
 
 // ブロックをフィールドに固定する
-pub fn fix_block(Game {field, pos, block }: &mut Game) {
+pub fn fix_block(Game { field, pos, block }: &mut Game) {
     for y in 0..4 {
         for x in 0..4 {
             if BLOCKS[*block as usize][y][x] == 1 {

--- a/chapter07/src/game.rs
+++ b/chapter07/src/game.rs
@@ -126,7 +126,7 @@ pub fn is_collision(field: &Field, pos: &Position, block: &BlockShape) -> bool {
 }
 
 // ブロックをフィールドに固定する
-pub fn fix_block(Game {field, pos, block }: &mut Game) {
+pub fn fix_block(Game { field, pos, block }: &mut Game) {
     for y in 0..4 {
         for x in 0..4 {
             if block[y][x] != block_kind::NONE {

--- a/chapter08/src/game.rs
+++ b/chapter08/src/game.rs
@@ -182,7 +182,7 @@ pub fn is_collision(field: &Field, pos: &Position, block: &BlockShape) -> bool {
 }
 
 // ブロックをフィールドに固定する
-pub fn fix_block(Game {field, pos, block, .. }: &mut Game) {
+pub fn fix_block(Game { field, pos, block, .. }: &mut Game) {
     for y in 0..4 {
         for x in 0..4 {
             if block[y][x] != block_kind::NONE {

--- a/chapter09/src/game.rs
+++ b/chapter09/src/game.rs
@@ -183,7 +183,7 @@ pub fn is_collision(field: &Field, pos: &Position, block: &BlockShape) -> bool {
 }
 
 // ブロックをフィールドに固定する
-pub fn fix_block(Game {field, pos, block, .. }: &mut Game) {
+pub fn fix_block(Game { field, pos, block, .. }: &mut Game) {
     for y in 0..4 {
         for x in 0..4 {
             if block[y][x] != block_kind::NONE {

--- a/chapter10/src/game.rs
+++ b/chapter10/src/game.rs
@@ -183,7 +183,7 @@ pub fn is_collision(field: &Field, pos: &Position, block: &BlockShape) -> bool {
 }
 
 // ブロックをフィールドに固定する
-pub fn fix_block(Game {field, pos, block, .. }: &mut Game) {
+pub fn fix_block(Game { field, pos, block, .. }: &mut Game) {
     for y in 0..4 {
         for x in 0..4 {
             if block[y][x] != block_kind::NONE {

--- a/tetrust/src/game.rs
+++ b/tetrust/src/game.rs
@@ -183,7 +183,7 @@ pub fn is_collision(field: &Field, pos: &Position, block: &BlockShape) -> bool {
 }
 
 // ブロックをフィールドに固定する
-pub fn fix_block(Game {field, pos, block, .. }: &mut Game) {
+pub fn fix_block(Game { field, pos, block, .. }: &mut Game) {
     for y in 0..4 {
         for x in 0..4 {
             if block[y][x] != block_kind::NONE {


### PR DESCRIPTION
とても楽しくRustを書ける記事をありがとうございます。
非常に細かい修正ですが、PR投げさせて頂きます。

## Changes
- `{ field, pos, block }`の誤りだと思われるので修正しました。
